### PR TITLE
Add video transcription endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -38,10 +38,17 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <!-- OpenAI client for accessing Whisper transcription API -->
+                <dependency>
+                        <groupId>com.theokanning.openai-gpt3-java</groupId>
+                        <artifactId>service</artifactId>
+                        <version>0.18.2</version>
+                </dependency>
 
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/src/main/java/szlicht/daniel/aiplayground/transcription/SubtitleService.java
+++ b/src/main/java/szlicht/daniel/aiplayground/transcription/SubtitleService.java
@@ -1,0 +1,33 @@
+package szlicht.daniel.aiplayground.transcription;
+
+import com.theokanning.openai.audio.CreateTranscriptionRequest;
+import com.theokanning.openai.audio.TranscriptionResult;
+import com.theokanning.openai.service.OpenAiService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+@Service
+public class SubtitleService {
+
+    private final OpenAiService openAiService;
+
+    public SubtitleService(@Value("${openai.api.key}") String apiKey) {
+        this.openAiService = new OpenAiService(apiKey);
+    }
+
+    public String transcribe(File videoFile) throws IOException {
+        CreateTranscriptionRequest request = CreateTranscriptionRequest.builder()
+                .model("whisper-1")
+                .responseFormat("text")
+                .build();
+
+        TranscriptionResult result = openAiService.createTranscription(request, videoFile);
+        // delete temp file after processing
+        Files.deleteIfExists(videoFile.toPath());
+        return result.getText();
+    }
+}

--- a/src/main/java/szlicht/daniel/aiplayground/transcription/TranscriptionController.java
+++ b/src/main/java/szlicht/daniel/aiplayground/transcription/TranscriptionController.java
@@ -1,0 +1,30 @@
+package szlicht.daniel.aiplayground.transcription;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api")
+public class TranscriptionController {
+
+    private final SubtitleService subtitleService;
+
+    public TranscriptionController(SubtitleService subtitleService) {
+        this.subtitleService = subtitleService;
+    }
+
+    @PostMapping(value = "/transcribe", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String transcribe(@RequestParam("file") MultipartFile file) throws IOException {
+        // Save the uploaded file to a temporary location
+        File temp = File.createTempFile("upload", ".mp4");
+        file.transferTo(temp);
+        return subtitleService.transcribe(temp);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=aiplayground
+# OpenAI API key used for generating subtitles
+openai.api.key=${OPENAI_API_KEY:}


### PR DESCRIPTION
## Summary
- add OpenAI service dependency
- allow configuring OpenAI API key via properties
- implement `SubtitleService` to call Whisper transcription API
- implement `TranscriptionController` for video upload

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6842c328eecc832c9970aedb9e21dc6d